### PR TITLE
Remove HTML comments when found in parameter values

### DIFF
--- a/wikiclass/extractors/enwiki.py
+++ b/wikiclass/extractors/enwiki.py
@@ -3,6 +3,8 @@ import re
 import sys
 import traceback
 
+import mwparserfromhell as mwp
+
 from .extractor import TemplateExtractor
 
 logger = logging.getLogger(__name__)

--- a/wikiclass/extractors/enwiki.py
+++ b/wikiclass/extractors/enwiki.py
@@ -15,6 +15,11 @@ def from_template(template):
         project_name = normalize_project_name(template_name)
         try:
             label = str(template.get('class').value).strip().lower()
+            if re.search(r'<!--', label): # HTML comment in param value?
+                label = mwp.parse(label)
+                label.remove(label.filter_comments())
+                label = str(label).strip()
+
             if label in POSSIBLE_LABELS:
                 return project_name, label
             else:

--- a/wikiclass/extractors/frwiki.py
+++ b/wikiclass/extractors/frwiki.py
@@ -3,6 +3,8 @@ import re
 import sys
 import traceback
 
+import mwparserfromhell as mwp
+
 from .extractor import TemplateExtractor
 
 logger = logging.getLogger(__name__)

--- a/wikiclass/extractors/frwiki.py
+++ b/wikiclass/extractors/frwiki.py
@@ -15,6 +15,7 @@ def from_template(template):
     if template_name == "wikiprojet" and template.has_param('avancement'):
         try:
             label = normalize_label(template.get('avancement').value)
+
             if label is not None:
                 return PROJECT_NAME, label
             else:
@@ -39,7 +40,11 @@ LABEL_MATCHES = [
 ]
 def normalize_label(value):
     value = str(value).lower().replace("_", " ").strip()
-
+    if re.search(r'<!--', value): # HTML comment in param value?
+        value = mwp.parse(value)
+        value.remove(value.filter_comments())
+        value = str(label).strip()
+    
     for label, regex in LABEL_MATCHES:
         if regex.match(value):
             return label

--- a/wikiclass/extractors/tests/test_enwiki.py
+++ b/wikiclass/extractors/tests/test_enwiki.py
@@ -32,7 +32,7 @@ def test_extractor():
         ),
         Revision(
             3, Timestamp(2), "aaa",
-            "{{talk page}}{{WikiProject Medicine|class=Stub}}..."
+            "{{talk page}}{{WikiProject Medicine|class=Stub<!-- test HTML comment -->}}..."
         ),
         Revision(
             4, Timestamp(3), "ccc",


### PR DESCRIPTION
HTML comments are found in WikiProject template parameter values at least on English Wikipedia, for example https://en.wikipedia.org/wiki/Talk:Fender_American_Deluxe_Series. The HTML comment is kept in the value leading to the label test failing and the page regarded as "not assessed".

Proposing a fix for this by regex-searching for "<!--" and if found, parsing the value and stripping out the comment(s).