### PR TITLE
Update classification examples to revscoring 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This library provides a set of utilities for performing automatic detection of a
 ## Basic usage
 
     >>> import wikiclass
-    >>> from revscoring.scorer_models import MLScorerModel
+    >>> from revscoring import Model
     >>>
-    >>> scorer_model = MLScorerModel.load(open("models/enwiki.wp10.rf.model", "rb"))
+    >>> scorer_model = Model.load(open("models/enwiki.nettrom_wp10.gradient_boosting.model", "rb"))
     >>>
     >>> text = "I am the text of a page.  I have a <ref>word</ref>"
     >>> wikiclass.score(scorer_model, text)

--- a/examples/classify_text.py
+++ b/examples/classify_text.py
@@ -1,15 +1,14 @@
-import pickle
-import sys;sys.path.insert(0, ".")
 from pprint import pprint
 
-from wikiclass.models import RFTextModel
+import wikiclass
+from revscoring import Model
 
-model = RFTextModel.from_file(open("enwiki.rf_text.model", "rb"))
+scorer_model = Model.load(open('../revscoring_models/enwiki.nettrom_wp10.gradient_boosting.model', 'rb'))
 
 # Classifies a revision of an article based on wikitext alone
 text = "An '''anachronism''' {{cite }}(from the [[Ancient Greek|Greek]] <ref ..."
-assessment, probs = model.classify(text)
+prediction_results = wikiclass.score(scorer_model, text)
 
 # Print predicted assessment class and probabilities for all classes.
-pprint(("assessment", assessment))
-pprint(("probs", probs))
+pprint(("assessment", prediction_results['prediction']))
+pprint(("probs", prediction_results['probability']))


### PR DESCRIPTION
The example usage described in the readme and in the classification example
in the "examples" folder used syntax from an older version. This commit
updates those two to use the newer syntax, as well as referring to the
current model in the repository.